### PR TITLE
Change add button from Gallery

### DIFF
--- a/App/Views/GalleryView.swift
+++ b/App/Views/GalleryView.swift
@@ -84,7 +84,7 @@ struct GalleryBoardView: View {
                     self.board.save()
                 }
             }) {
-                Label("Add Board", systemImage: "plus.circle.fill")
+                Label(self.isInstalled ? "Added" : "Add Board", systemImage: self.isInstalled ? "checkmark.circle.fill" : "plus.circle.fill")
                     .font(.headline)
                     .aligned(to: .horizontal)
             }


### PR DESCRIPTION
Small improvement to the "Add Board" button in the Gallery. Now after clicking "Add Board", the button changes to "Added". Users can still add the board again and will receive the alert afterwards, but this lets them know that the button action worked the first time