### PR TITLE
Stop sound when deleted or removed from board

### DIFF
--- a/App/Elements/SoundButton.swift
+++ b/App/Elements/SoundButton.swift
@@ -62,6 +62,7 @@ struct SoundButton: View {
                     Button(role: .destructive, action: {
                         board.sounds.removeAll(where: { $0 == self.sound.id })
                         Defaults[.boards].upsert(board, by: \.id)
+                        player?.stop()
                     }) {
                         Label("Remove From Board", systemImage: "trash")
                     }
@@ -72,6 +73,7 @@ struct SoundButton: View {
                         board.sounds.removeAll(where: { $0 == self.sound.id })
                         Defaults[.boards].upsert(board, by: \.id)
                     }
+                    player?.stop()
                 }) {
                     Label("Delete Sound", systemImage: "trash")
                 }


### PR DESCRIPTION
From Plumkewe's suggestion in this issue:
https://github.com/unorderly/Klang/issues/5

"4. When reproducing a sound and in the meantime deleting it, it doesn't stop playing
there's another bug that occasionally occurs, which i couldn't reproduce."

I was able to reproduce it, and now the sound stops both when deleting it from the board or when just removing it