### PR TITLE
Feature/stop sound widget

### DIFF
--- a/App/IntentRunner.swift
+++ b/App/IntentRunner.swift
@@ -11,19 +11,29 @@ import UIKit
 import MediaPlayer
 
 enum IntentRunner {
+    private static var player: AudioPlayer?
+
     static func perform(intent: SoundIntent) async throws -> some IntentResult {
+        if let currentPlayer = player, currentPlayer.isPlaying {
+            print("Stopping sound \(intent.sound.title)")
+            currentPlayer.stop()
+            player = nil
+            return .result()
+        }
+
         print("Start playing \(intent.sound.title)")
-        let player = try! AudioPlayer(url: intent.sound.file.fileURL!)
+        let newPlayer = try! AudioPlayer(url: intent.sound.file.fileURL!)
+        player = newPlayer
 
         print("Created sound for \(intent.sound.title)")
 
-        if intent.isFullBlast && player.isOnSpeaker {
+        if intent.isFullBlast && newPlayer.isOnSpeaker {
             await MPVolumeView.setVolume(1)
         }
 
         do {
             print("Playing sound \(intent.sound.title)")
-            try await player.playOnQueue()
+            try await newPlayer.playOnQueue()
             print("Sound \(intent.sound.title) stopped")
         } catch {
             print("Playing Sound fauled error:", error.localizedDescription)

--- a/App/IntentRunner.swift
+++ b/App/IntentRunner.swift
@@ -24,7 +24,12 @@ enum IntentRunner {
         }
 
         guard let fileURL = intent.sound.file.fileURL, let newPlayer = try? AudioPlayer(url: fileURL) else {
-            print("Failed to create player for \(intent.sound.title)")
+            let errorMessage = "There was a error in the Widget"
+            print(errorMessage)
+            DispatchQueue.main.async {
+                AudioErrorManager.errorManager.errorMessage = errorMessage
+                AudioErrorManager.errorManager.showWidgetError = true
+            }
             return .result()
         }
         print("Start playing \(intent.sound.title)")
@@ -39,13 +44,16 @@ enum IntentRunner {
 
         do {
             print("Playing sound \(intent.sound.title)")
+            defer { activePlayer[soundID] = nil }
             try await newPlayer.playOnQueue()
             print("Sound \(intent.sound.title) stopped")
-
-            activePlayer[intent.sound.id] = nil
         } catch {
-            print("Playing Sound failed error:", error.localizedDescription)
-            activePlayer[intent.sound.id] = nil
+            let errorMessage = "There was a error playing sound in the Widget"
+            print(errorMessage)
+            DispatchQueue.main.async {
+                AudioErrorManager.errorManager.errorMessage = errorMessage
+                AudioErrorManager.errorManager.showWidgetError = true
+            }
         }
         return .result()
     }

--- a/App/IntentRunner.swift
+++ b/App/IntentRunner.swift
@@ -11,19 +11,20 @@ import UIKit
 import MediaPlayer
 
 enum IntentRunner {
-    private static var player: AudioPlayer?
+    private static var currentPlayer: AudioPlayer?
+    private static var currentSoundTitle: String?
 
     static func perform(intent: SoundIntent) async throws -> some IntentResult {
-        if let currentPlayer = player, currentPlayer.isPlaying {
+        if let player = currentPlayer, player.isPlaying, currentSoundTitle == intent.sound.title {
             print("Stopping sound \(intent.sound.title)")
-            currentPlayer.stop()
-            player = nil
+            player.stop()
+            currentPlayer = nil
+            currentSoundTitle = nil
             return .result()
         }
 
         print("Start playing \(intent.sound.title)")
         let newPlayer = try! AudioPlayer(url: intent.sound.file.fileURL!)
-        player = newPlayer
 
         print("Created sound for \(intent.sound.title)")
 
@@ -31,12 +32,22 @@ enum IntentRunner {
             await MPVolumeView.setVolume(1)
         }
 
+        currentPlayer = newPlayer
+        currentSoundTitle = intent.sound.title
+
         do {
             print("Playing sound \(intent.sound.title)")
             try await newPlayer.playOnQueue()
             print("Sound \(intent.sound.title) stopped")
+
+            if currentSoundTitle == intent.sound.title {
+                currentPlayer = nil
+                currentSoundTitle = nil
+            }
         } catch {
-            print("Playing Sound fauled error:", error.localizedDescription)
+            print("Playing Sound failed error:", error.localizedDescription)
+            currentPlayer = nil
+            currentSoundTitle = nil
         }
         return .result()
     }

--- a/App/IntentRunner.swift
+++ b/App/IntentRunner.swift
@@ -24,23 +24,16 @@ enum IntentRunner {
         }
 
         guard let fileURL = intent.sound.file.fileURL, let newPlayer = try? AudioPlayer(url: fileURL) else {
-            let errorMessage = "There was a error in the Widget"
-            print(errorMessage)
-            DispatchQueue.main.async {
-                AudioErrorManager.errorManager.errorMessage = errorMessage
-                AudioErrorManager.errorManager.showWidgetError = true
-            }
+            AudioErrorManager.errorManager.reportError("There was a error in the Widget")
             return .result()
         }
-        print("Start playing \(intent.sound.title)")
 
+        activePlayer[soundID] = newPlayer
         print("Created sound for \(intent.sound.title)")
 
         if intent.isFullBlast && newPlayer.isOnSpeaker {
             await MPVolumeView.setVolume(1)
         }
-
-        activePlayer[soundID] = newPlayer
 
         do {
             print("Playing sound \(intent.sound.title)")
@@ -48,12 +41,7 @@ enum IntentRunner {
             try await newPlayer.playOnQueue()
             print("Sound \(intent.sound.title) stopped")
         } catch {
-            let errorMessage = "There was a error playing sound in the Widget"
-            print(errorMessage)
-            DispatchQueue.main.async {
-                AudioErrorManager.errorManager.errorMessage = errorMessage
-                AudioErrorManager.errorManager.showWidgetError = true
-            }
+            AudioErrorManager.errorManager.reportError("There was a error playing sound in the Widget")
         }
         return .result()
     }

--- a/App/IntentRunner.swift
+++ b/App/IntentRunner.swift
@@ -11,20 +11,23 @@ import UIKit
 import MediaPlayer
 
 enum IntentRunner {
-    private static var activePlayer: [String: AudioPlayer] = [:]
+    private static var activePlayer: [UUID: AudioPlayer] = [:]
 
     static func perform(intent: SoundIntent) async throws -> some IntentResult {
-        let soundTitle = intent.sound.title
+        let soundID = intent.sound.id
 
-        if let player = activePlayer[soundTitle], player.isPlaying {
+        if let player = activePlayer[soundID], player.isPlaying {
             print("Stopping sound \(intent.sound.title)")
             player.stop()
-            activePlayer[soundTitle] = nil
+            activePlayer[soundID] = nil
             return .result()
         }
 
+        guard let fileURL = intent.sound.file.fileURL, let newPlayer = try? AudioPlayer(url: fileURL) else {
+            print("Failed to create player for \(intent.sound.title)")
+            return .result()
+        }
         print("Start playing \(intent.sound.title)")
-        let newPlayer = try! AudioPlayer(url: intent.sound.file.fileURL!)
 
         print("Created sound for \(intent.sound.title)")
 
@@ -32,17 +35,17 @@ enum IntentRunner {
             await MPVolumeView.setVolume(1)
         }
 
-        activePlayer[soundTitle] = newPlayer
+        activePlayer[soundID] = newPlayer
 
         do {
             print("Playing sound \(intent.sound.title)")
             try await newPlayer.playOnQueue()
             print("Sound \(intent.sound.title) stopped")
 
-            activePlayer[intent.sound.title] = nil
+            activePlayer[intent.sound.id] = nil
         } catch {
             print("Playing Sound failed error:", error.localizedDescription)
-            activePlayer[intent.sound.title] = nil
+            activePlayer[intent.sound.id] = nil
         }
         return .result()
     }

--- a/App/Views/MainView.swift
+++ b/App/Views/MainView.swift
@@ -181,6 +181,13 @@ class AudioErrorManager: ObservableObject {
     static let errorManager = AudioErrorManager()
     @Published var errorMessage: String?
     @Published var showWidgetError: Bool = false
+
+    func reportError(_ message: String) {
+        DispatchQueue.main.async {
+            self.errorMessage = message
+            self.showWidgetError = true
+        }
+    }
 }
 
 #Preview {

--- a/App/Views/MainView.swift
+++ b/App/Views/MainView.swift
@@ -39,6 +39,8 @@ struct MainView: View {
 
     @ScaledMetric(relativeTo: .headline) var minimumWidth: CGFloat = 130
 
+    @StateObject private var errorManager = AudioErrorManager.errorManager
+
     var body: some View {
         NavigationSplitView(preferredCompactColumn: $preferredCompactColumn, sidebar: {
             ScrollView(.vertical) {
@@ -144,7 +146,11 @@ struct MainView: View {
                 GalleryBoard.animals.save()
             }
         }
-
+        .alert("Error", isPresented: $errorManager.showWidgetError) {
+            Button("OK") { }
+        } message: {
+            Text(errorManager.errorMessage ?? "Unknown error")
+        }
     }
 }
 
@@ -171,6 +177,11 @@ extension Array {
     }
 }
 
+class AudioErrorManager: ObservableObject {
+    static let errorManager = AudioErrorManager()
+    @Published var errorMessage: String?
+    @Published var showWidgetError: Bool = false
+}
 
 #Preview {
     MainView()


### PR DESCRIPTION
Fix based on the suggestion in this ticket:
https://github.com/unorderly/Klang/issues/7

Now there’s a consistent behavior between the app and the widget. Also updated to use the id instead of the title because if two sounds had the same name, both would get stopped. You can now play multiple sounds and stop them individually!