### PR TITLE
Color Picker and Color Palette

### DIFF
--- a/App/Elements/ColorPalette.swift
+++ b/App/Elements/ColorPalette.swift
@@ -1,0 +1,12 @@
+//
+//  Untitled.swift
+//  Klang
+//
+//  Created by Mariela  on 21.02.25.
+//
+
+import SwiftUI
+
+public struct ColorPalette {
+    public static let colors: [Color] = [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
+}

--- a/App/Elements/ColorPalette.swift
+++ b/App/Elements/ColorPalette.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
-public struct ColorPalette {
-    public static let colors: [Color] = [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
+extension Color {
+    static var palette: [Color] {
+        [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
+    }
 }

--- a/App/Elements/ColorRow.swift
+++ b/App/Elements/ColorRow.swift
@@ -16,10 +16,6 @@ struct ColorSizeKey: PreferenceKey {
     }
 }
 
-public struct ColorPalette {
-    public static let colors: [Color] = [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
-}
-
 public struct ColorRow: View {
     @Binding public var selected: Color
 

--- a/App/Elements/ColorRow.swift
+++ b/App/Elements/ColorRow.swift
@@ -115,6 +115,6 @@ public struct ColorRow: View {
     }
 }
 #Preview {
-    ColorRow(selected: .constant(.red), colors: ColorPalette.colors)
+    ColorRow(selected: .constant(.red), colors: Color.palette)
         .padding()
 }

--- a/App/Elements/ColorRow.swift
+++ b/App/Elements/ColorRow.swift
@@ -48,12 +48,7 @@ public struct ColorRow: View {
             ColorPicker("Color Picker",
                         selection: $selectedColor,
                         supportsOpacity: false)
-            .onChange(of: selectedColor) {
-                custom = selectedColor
-            }
-            .onAppear {
-                selectedColor = custom
-            }
+                .debounce(from: $selectedColor, to: $custom)
             .accessibilityAddTraits(!self.colors.contains(self.selected) ? .isSelected : [])
             .labelsHidden()
             .background(GeometryReader {

--- a/App/Elements/ColorRow.swift
+++ b/App/Elements/ColorRow.swift
@@ -31,6 +31,7 @@ public struct ColorRow: View {
     @State private var size: CGSize = .init(width: 22, height: 22)
 
     @State private var custom: Color = .clear
+    @State private var selectedColor: Color = .clear
 
     public var body: some View {
         HStack(spacing: 0) {
@@ -46,10 +47,15 @@ public struct ColorRow: View {
                 }
             }
 
-           
             ColorPicker("Color Picker",
-                        selection: $custom,
+                        selection: $selectedColor,
                         supportsOpacity: false)
+            .onChange(of: selectedColor) {
+                custom = selectedColor
+            }
+            .onAppear {
+                selectedColor = custom
+            }
             .accessibilityAddTraits(!self.colors.contains(self.selected) ? .isSelected : [])
             .labelsHidden()
             .background(GeometryReader {

--- a/App/Elements/ColorRow.swift
+++ b/App/Elements/ColorRow.swift
@@ -16,7 +16,9 @@ struct ColorSizeKey: PreferenceKey {
     }
 }
 
-
+public struct ColorPalette {
+    public static let colors: [Color] = [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
+}
 
 public struct ColorRow: View {
     @Binding public var selected: Color
@@ -117,6 +119,6 @@ public struct ColorRow: View {
     }
 }
 #Preview {
-    ColorRow(selected: .constant(.red), colors: [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow])
+    ColorRow(selected: .constant(.red), colors: ColorPalette.colors)
         .padding()
 }

--- a/App/Helper/DebounceBinding.swift
+++ b/App/Helper/DebounceBinding.swift
@@ -1,0 +1,58 @@
+import Combine
+import SwiftUI
+
+struct DebounceBindingModifier<Value: Equatable>: ViewModifier {
+    @Binding var global: Value
+    @Binding var local: Value
+
+    var delay: RunLoop.SchedulerTimeType.Stride
+
+    @State private var localPublisher: PassthroughSubject<Value, Never> = .init()
+
+    let onChange: (Value) -> Void
+    init(global: Binding<Value>,
+         local: Binding<Value>,
+         delay: RunLoop.SchedulerTimeType.Stride,
+         onChange: @escaping (Value) -> Void = { _ in }) {
+        self._global = global
+        self._local = local
+        self.delay = delay
+        self.onChange = onChange
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: self.local, perform: { value in
+                self.localPublisher.send(value)
+            })
+            .onReceive(self.localPublisher
+                .removeDuplicates()
+                .debounce(for: self.delay, scheduler: RunLoop.main)) { value in
+                    if self.global != value {
+                        self.global = value
+                        self.onChange(value)
+                    }
+            }
+            .onDisappear {
+                if self.global != self.local {
+                    self.global = self.local
+                    self.onChange(self.local)
+                }
+            }
+            .onAppear {
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    self.local = self.global
+                }
+            }
+    }
+}
+
+extension View {
+    public func debounce<Value: Equatable>(from local: Binding<Value>, to global: Binding<Value>, // asdf
+                                           for delay: RunLoop.SchedulerTimeType.Stride = 0.3,
+                                           onChange: @escaping (Value) -> Void = { _ in }) -> some View {
+        self.modifier(DebounceBindingModifier(global: global, local: local, delay: delay, onChange: onChange))
+    }
+}

--- a/App/Views/BoardEditor.swift
+++ b/App/Views/BoardEditor.swift
@@ -71,7 +71,7 @@ struct BoardEditor: View {
                             .font(.title3.weight(.semibold))
                     }
 
-                    ColorRow(selected: $color, colors: ColorPalette.colors)
+                    ColorRow(selected: $color, colors: Color.palette)
                         .padding(6)
 
                 }

--- a/App/Views/BoardEditor.swift
+++ b/App/Views/BoardEditor.swift
@@ -47,11 +47,6 @@ struct BoardEditor: View {
                   isExisting: true)
     }
 
-    var presetColors: [Color] {
-        [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
-    }
-
-
     var body: some View {
         NavigationStack {
             Form {
@@ -76,7 +71,7 @@ struct BoardEditor: View {
                             .font(.title3.weight(.semibold))
                     }
 
-                    ColorRow(selected: $color, colors: self.presetColors)
+                    ColorRow(selected: $color, colors: ColorPalette.colors)
                         .padding(6)
 
                 }

--- a/App/Views/BoardView.swift
+++ b/App/Views/BoardView.swift
@@ -136,7 +136,7 @@ struct BoardView: View {
                 do {
                     try FileManager.default.copyItem(at: url, to: tempURL)
 
-                    let newSound = Sound(id: UUID(), title: "Imported Sound", symbol: "🚦", color: ColorPalette.colors.randomElement()!, url: tempURL)
+                    let newSound = Sound(id: UUID(), title: "Imported Sound", symbol: "🚦", color: Color.palette.randomElement()!, url: tempURL)
                     Defaults[.sounds].upsert(newSound, by: \.id)
 
                     if let boardID = self.board?.id, var board = Defaults[.boards].first(where: { $0.id == boardID }) {

--- a/App/Views/BoardView.swift
+++ b/App/Views/BoardView.swift
@@ -136,7 +136,7 @@ struct BoardView: View {
                 do {
                     try FileManager.default.copyItem(at: url, to: tempURL)
 
-                    let newSound = Sound(id: UUID(), title: "Imported Sound", symbol: "🚦", color: .orange, url: tempURL)
+                    let newSound = Sound(id: UUID(), title: "Imported Sound", symbol: "🚦", color: ColorPalette.colors.randomElement()!, url: tempURL)
                     Defaults[.sounds].upsert(newSound, by: \.id)
 
                     if let boardID = self.board?.id, var board = Defaults[.boards].first(where: { $0.id == boardID }) {

--- a/App/Views/EditorView.swift
+++ b/App/Views/EditorView.swift
@@ -19,7 +19,6 @@ struct EditorView: View {
     @State var isImporting: Bool = false
     @State var isEmojiPickerPresent: Bool = false
     
-    
     @State var id: UUID = .init()
     
     @State var isExisting = false
@@ -64,11 +63,7 @@ struct EditorView: View {
                   isExisting: true,
                   boardID: boardID)
     }
-    
-    var presetColors: [Color] {
-        [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
-    }
-    
+
     var body: some View {
         NavigationStack {
             Form {
@@ -93,11 +88,9 @@ struct EditorView: View {
                             .font(.title3.weight(.semibold))
                     }
                     
-                    ColorRow(selected: $color, colors: self.presetColors)
+                    ColorRow(selected: $color, colors: ColorPalette.colors)
                         .padding(6)
-                    
                 }
-                
                 
                 Section {
                     if let url = self.file {

--- a/App/Views/EditorView.swift
+++ b/App/Views/EditorView.swift
@@ -88,7 +88,7 @@ struct EditorView: View {
                             .font(.title3.weight(.semibold))
                     }
                     
-                    ColorRow(selected: $color, colors: ColorPalette.colors)
+                    ColorRow(selected: $color, colors: Color.palette)
                         .padding(6)
                 }
                 

--- a/Klang.xcodeproj/project.pbxproj
+++ b/Klang.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3699CAE62D6755C5007183D1 /* ColorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30FD83C2A6E5A1800990160 /* ColorRow.swift */; };
 		B30338E72A30D06300CEDD47 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30338E62A30D06300CEDD47 /* App.swift */; };
 		B30338E92A30D06300CEDD47 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30338E82A30D06300CEDD47 /* MainView.swift */; };
 		B30338EB2A30D06300CEDD47 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B30338EA2A30D06300CEDD47 /* Assets.xcassets */; };
@@ -646,6 +647,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3699CAE62D6755C5007183D1 /* ColorRow.swift in Sources */,
 				B30339432A30D34D00CEDD47 /* View.swift in Sources */,
 				B34C78422A8FBFC8009A8BAA /* BoardEntity.swift in Sources */,
 				B34040282A398F1800A1D23E /* Color.swift in Sources */,

--- a/Klang.xcodeproj/project.pbxproj
+++ b/Klang.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3699CAE62D6755C5007183D1 /* ColorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30FD83C2A6E5A1800990160 /* ColorRow.swift */; };
+		3668524B2D68837300082787 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3668524A2D68837100082787 /* ColorPalette.swift */; };
+		3668524C2D6883CC00082787 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3668524A2D68837100082787 /* ColorPalette.swift */; };
 		B30338E72A30D06300CEDD47 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30338E62A30D06300CEDD47 /* App.swift */; };
 		B30338E92A30D06300CEDD47 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30338E82A30D06300CEDD47 /* MainView.swift */; };
 		B30338EB2A30D06300CEDD47 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B30338EA2A30D06300CEDD47 /* Assets.xcassets */; };
@@ -123,6 +124,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3668524A2D68837100082787 /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
 		B30338E32A30D06300CEDD47 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B30338E62A30D06300CEDD47 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		B30338E82A30D06300CEDD47 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 		B3D3BE132A9B413700D7C077 /* Elements */ = {
 			isa = PBXGroup;
 			children = (
+				3668524A2D68837100082787 /* ColorPalette.swift */,
 				B34C78382A8FB262009A8BAA /* BoardButton.swift */,
 				B34C78362A8FB1CF009A8BAA /* SoundButton.swift */,
 				B30FD8412A6E637B00990160 /* RecordingButton.swift */,
@@ -609,6 +612,7 @@
 				B30FD8482A6E8AB100990160 /* TempiFFT.swift in Sources */,
 				B34C78392A8FB262009A8BAA /* BoardButton.swift in Sources */,
 				B32193302A3FAD0C0050B011 /* EditorView.swift in Sources */,
+				3668524B2D68837300082787 /* ColorPalette.swift in Sources */,
 				B3D6E03A2AA0CCA60078A6A9 /* FadeBackground.swift in Sources */,
 				B3DD59DD2A6B070500314F4E /* AudioRecorder.swift in Sources */,
 				B34C783B2A8FBE10009A8BAA /* SoundEntity.swift in Sources */,
@@ -647,12 +651,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3699CAE62D6755C5007183D1 /* ColorRow.swift in Sources */,
 				B30339432A30D34D00CEDD47 /* View.swift in Sources */,
 				B34C78422A8FBFC8009A8BAA /* BoardEntity.swift in Sources */,
 				B34040282A398F1800A1D23E /* Color.swift in Sources */,
 				B303394F2A30D39C00CEDD47 /* Intent.swift in Sources */,
 				B32BF3452A38E7D3005BFA59 /* Alignment.swift in Sources */,
+				3668524C2D6883CC00082787 /* ColorPalette.swift in Sources */,
 				B3EF669F2AAA2484008FF8A6 /* IntentRunner.swift in Sources */,
 				B30339452A30D34D00CEDD47 /* ConfigurationIntent.swift in Sources */,
 				B32BF35F2A39891F005BFA59 /* AsyncButton.swift in Sources */,

--- a/Klang.xcodeproj/project.pbxproj
+++ b/Klang.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3668524B2D68837300082787 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3668524A2D68837100082787 /* ColorPalette.swift */; };
 		3668524C2D6883CC00082787 /* ColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3668524A2D68837100082787 /* ColorPalette.swift */; };
+		36F4FE4A2D6C8E7E00018421 /* DebounceBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36F4FE492D6C8E7700018421 /* DebounceBinding.swift */; };
 		B30338E72A30D06300CEDD47 /* App.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30338E62A30D06300CEDD47 /* App.swift */; };
 		B30338E92A30D06300CEDD47 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30338E82A30D06300CEDD47 /* MainView.swift */; };
 		B30338EB2A30D06300CEDD47 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B30338EA2A30D06300CEDD47 /* Assets.xcassets */; };
@@ -125,6 +126,7 @@
 
 /* Begin PBXFileReference section */
 		3668524A2D68837100082787 /* ColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPalette.swift; sourceTree = "<group>"; };
+		36F4FE492D6C8E7700018421 /* DebounceBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebounceBinding.swift; sourceTree = "<group>"; };
 		B30338E32A30D06300CEDD47 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B30338E62A30D06300CEDD47 /* App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App.swift; sourceTree = "<group>"; };
 		B30338E82A30D06300CEDD47 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 		B321932E2A3FACAD0050B011 /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				36F4FE492D6C8E7700018421 /* DebounceBinding.swift */,
 				B3D6E0392AA0CCA60078A6A9 /* FadeBackground.swift */,
 				B3D270F62A92088D007D05A9 /* Fuse.swift */,
 				B34C78302A8F8463009A8BAA /* Modify.swift */,
@@ -616,6 +619,7 @@
 				B3D6E03A2AA0CCA60078A6A9 /* FadeBackground.swift in Sources */,
 				B3DD59DD2A6B070500314F4E /* AudioRecorder.swift in Sources */,
 				B34C783B2A8FBE10009A8BAA /* SoundEntity.swift in Sources */,
+				36F4FE4A2D6C8E7E00018421 /* DebounceBinding.swift in Sources */,
 				B3A8FD442A71000500357001 /* AudioPlayer.swift in Sources */,
 				B30FD8442A6E7DEB00990160 /* WaveformView.swift in Sources */,
 				B34C78332A8FAE09009A8BAA /* BoardView.swift in Sources */,

--- a/Widget/View.swift
+++ b/Widget/View.swift
@@ -31,7 +31,7 @@ struct SoundWidgetEmptyView: View {
                     HStack(spacing: 12) {
                         ForEach(Array(0..<(self.rows * widgetFamily.aspectRatio)), id: \.self) { _ in
                             ContainerRelativeShape()
-                                .foregroundStyle(ColorPalette.colors.randomElement()!)
+                                .foregroundStyle(Color.palette.randomElement()!)
                                 .opacity(0.3)
                         }
                     }

--- a/Widget/View.swift
+++ b/Widget/View.swift
@@ -12,10 +12,6 @@ import Defaults
 struct SoundWidgetEmptyView: View {
     @Environment(\.widgetFamily) var widgetFamily
 
-    var colors: [Color] {
-        [.red, .blue, .green, .indigo, .mint, .orange, .pink, .purple, .teal, .yellow]
-    }
-
     var rows: Int {
         switch widgetFamily {
         case .accessoryCircular, .accessoryRectangular:
@@ -35,7 +31,7 @@ struct SoundWidgetEmptyView: View {
                     HStack(spacing: 12) {
                         ForEach(Array(0..<(self.rows * widgetFamily.aspectRatio)), id: \.self) { _ in
                             ContainerRelativeShape()
-                                .foregroundStyle(self.colors.randomElement()!)
+                                .foregroundStyle(ColorPalette.colors.randomElement()!)
                                 .opacity(0.3)
                         }
                     }


### PR DESCRIPTION
Apparently there’s an issue with the native `ColorPciker`, where the color selection was often defaulting to black, regardless of the mode (grid, spectrum, or sliders). Now users can freely select colors as expected!

I also added a `ColorPalette` struct to avoid repeating color definitions in different parts of the code. This makes it easier to update colors in one place rinstead of modifying the multiple instances. I placed `ColorPalette` in the `ColorRow` file and added the Widget target so it could also be used in View (SoundWidgetEmptyView). Let me know if you’d prefer it in a separate file

And added a random color when importing sounds to add a bit of variety

**Before and After:**

https://github.com/user-attachments/assets/41537148-d8f9-45ae-bbc0-8a179616913e


https://github.com/user-attachments/assets/18ffb139-176f-4b01-8bf3-1bdf35aaeba9



